### PR TITLE
Add price prediction training and API

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Create and AI app which will scan your furniture and provide the condition state
 ✅ Frontend (Flutter/React Native)
 ✅ Backend (FastAPI for AI integration)
 ✅ ML Models (YOLOv8 for object detection, CNN for condition assessment, XGBoost for price prediction)
+✅ Price predictor training script (`models/train_price_predictor.py`) and FastAPI endpoint (`backend/predict_price.py`)
 ✅ Dataset preprocessing scripts
 ✅ Scraping scripts for second-hand price data
 
@@ -20,3 +21,17 @@ Improve AI Detection:
 
 Integrate thermal imaging (if feasible) for termite detection.
 Fine-tune XGBoost model for better price prediction.
+
+## Usage
+
+Train the resale price model:
+
+```bash
+python models/train_price_predictor.py
+```
+
+Run the prediction API:
+
+```bash
+uvicorn backend.predict_price:app --reload
+```

--- a/backend/predict_price.py
+++ b/backend/predict_price.py
@@ -1,0 +1,55 @@
+from fastapi import FastAPI, UploadFile, File
+from pydantic import BaseModel
+from PIL import Image
+import numpy as np
+import pandas as pd
+import xgboost as xgb
+from tensorflow.keras.models import load_model
+
+# Load models
+condition_model = load_model('models/condition_classifier.h5')
+price_model = xgb.XGBRegressor()
+price_model.load_model('models/price_predictor.json')
+
+app = FastAPI()
+
+class FurnitureMetadata(BaseModel):
+    age: float
+    wood_type: str
+    material_type: str
+
+
+def get_wear_score(image: Image.Image) -> float:
+    img = image.resize((224, 224))
+    arr = np.array(img) / 255.0
+    arr = np.expand_dims(arr, axis=0)
+    pred = condition_model.predict(arr)
+    return float(pred[0][0])
+
+
+@ app.post('/predict_price')
+async def predict_price(meta: FurnitureMetadata, image: UploadFile = File(...)):
+    img = Image.open(image.file)
+    wear_score = get_wear_score(img)
+
+    df = pd.DataFrame([{
+        'age': meta.age,
+        'wear_score': wear_score,
+        'wood_type': meta.wood_type,
+        'material_type': meta.material_type,
+    }])
+
+    df = pd.get_dummies(df)
+    required_cols = price_model.get_booster().feature_names
+    for col in required_cols:
+        if col not in df.columns:
+            df[col] = 0
+    df = df[required_cols]
+
+    price = price_model.predict(df)[0]
+    return {
+        'estimated_price': float(price),
+        'wear_score': wear_score
+    }
+
+

--- a/models/train_price_predictor.py
+++ b/models/train_price_predictor.py
@@ -1,0 +1,33 @@
+import pandas as pd
+import xgboost as xgb
+from sklearn.model_selection import train_test_split
+from sklearn.metrics import mean_absolute_error
+
+# Load training data
+# Expected columns: age, wear_score, wood_type, material_type, price
+# Additional categorical features can be included
+
+data = pd.read_csv('datasets/price_data.csv')
+
+# One-hot encode categorical features
+categorical_cols = ['wood_type', 'material_type']
+data = pd.get_dummies(data, columns=categorical_cols)
+
+X = data.drop('price', axis=1)
+y = data['price']
+
+X_train, X_val, y_train, y_val = train_test_split(X, y, test_size=0.2, random_state=42)
+
+model = xgb.XGBRegressor(
+    objective='reg:squarederror',
+    n_estimators=300,
+    learning_rate=0.05,
+    max_depth=5,
+)
+model.fit(X_train, y_train)
+
+preds = model.predict(X_val)
+print('MAE:', mean_absolute_error(y_val, preds))
+
+# Save model
+model.save_model('models/price_predictor.json')


### PR DESCRIPTION
## Summary
- implement XGBoost training script for price prediction
- add FastAPI endpoint to generate furniture price estimates
- document usage in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6847e9dac060832bb9df2cbc164823dc